### PR TITLE
fix: support relative PWA assets for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Aplicación CRM ligera.
 ## PWA
 
 Esta versión incluye configuración básica como `manifest.json` y `service-worker.js` para usarlo como PWA y un servidor WebSocket con Baileys para conectar a WhatsApp.
+
+### GitHub Pages
+
+Las rutas de `service-worker.js` y `manifest.json` se manejan de forma relativa para que la aplicación pueda desplegarse en subcarpetas como GitHub Pages. La URL del WebSocket puede personalizarse asignando `window.ENV.WS_URL` antes de cargar la aplicación.

--- a/index.jsx
+++ b/index.jsx
@@ -81,6 +81,7 @@ const CONFIG = {
   BUILDERBOT_BASE_URL: (window as any).ENV?.BUILDERBOT_BASE_URL || "http://localhost:3008",
   BUILDERBOT_API_KEY: (window as any).ENV?.BUILDERBOT_API_KEY || "",
   ASSISTANT_GATEWAY: (window as any).ENV?.ASSISTANT_GATEWAY || "http://localhost:3008",
+  WS_URL: (window as any).ENV?.WS_URL || "ws://localhost:4000",
 };
 
 const uid = () => Math.random().toString(36).slice(2);
@@ -99,7 +100,7 @@ const saveDB = (db: DB) => localStorage.setItem("agua_bambu_crm_db", JSON.string
 let waSocket: WebSocket | null = null;
 function initWASocket(){
   if(!waSocket || waSocket.readyState === WebSocket.CLOSED){
-    waSocket = new WebSocket('ws://localhost:4000');
+    waSocket = new WebSocket(CONFIG.WS_URL);
     waSocket.addEventListener('open', () => console.log('WhatsApp socket conectado'));
   }
 }
@@ -143,7 +144,7 @@ export default function CRMKommoStyle(){
 
   useEffect(()=>{
     if('serviceWorker' in navigator){
-      navigator.serviceWorker.register('/service-worker.js').catch(console.error);
+      navigator.serviceWorker.register('service-worker.js').catch(console.error);
     }
     initWASocket();
     return () => { waSocket?.close(); };

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open('crm-bambu-cache').then(cache => cache.add('/manifest.json'))
+    caches.open('crm-bambu-cache').then(cache => cache.add('manifest.json'))
   );
 });
 


### PR DESCRIPTION
## Summary
- use relative URL when registering service worker for deployment on subpaths
- allow WebSocket endpoint to be configured via `window.ENV.WS_URL`
- document GitHub Pages setup and make manifest caching relative

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb028d5a1c832da962d69707265810