### PR TITLE
fix: support relative PWA assets for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ Aplicación CRM ligera.
 ## PWA
 
 Esta versión incluye configuración básica como `manifest.json` y `service-worker.js` para usarlo como PWA y un servidor WebSocket con Baileys para conectar a WhatsApp.
+
+### GitHub Pages
+
+Las rutas de `service-worker.js` y `manifest.json` se manejan de forma relativa para que la aplicación pueda desplegarse en subcarpetas como GitHub Pages. La URL del WebSocket puede personalizarse asignando `window.ENV.WS_URL` antes de cargar la aplicación.
+
+La aplicación incluye un `index.html` que carga los componentes con Babel y módulos ES desde CDN, por lo que basta con habilitar GitHub Pages en la rama principal para probarla.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CRM Bambu</title>
+  <link rel="manifest" href="./manifest.json" />
+</head>
+<body>
+  <div id="root"></div>
+  <script>
+    window.ENV = window.ENV || {}; // configure WS_URL if needed
+  </script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" data-presets="typescript,react" src="./index.jsx"></script>
+</body>
+</html>

--- a/index.jsx
+++ b/index.jsx
@@ -1,13 +1,39 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
-import { Switch } from "@/components/ui/switch";
-import { Badge } from "@/components/ui/badge";
+import React, { useEffect, useMemo, useRef, useState } from "https://esm.sh/react@18";
+
+function Card({ children, ...props }){ return <div {...props}>{children}</div>; }
+function CardContent({ children, ...props }){ return <div {...props}>{children}</div>; }
+function Button({ children, ...props }){ return <button {...props}>{children}</button>; }
+function Input(props){ return <input {...props} />; }
+function Textarea(props){ return <textarea {...props} />; }
+function Select({ value, onValueChange, children, ...props }){
+  let content = null;
+  React.Children.forEach(children, child => { if(child.type === SelectContent) content = child; });
+  const options = content ? React.Children.map(content.props.children, item => <option value={item.props.value}>{item.props.children}</option>) : null;
+  return <select value={value} onChange={e=> onValueChange(e.target.value)} {...props}>{options}</select>;
+}
+function SelectTrigger({ children }){ return <>{children}</>; }
+function SelectValue(){ return null; }
+function SelectContent({ children }){ return <>{children}</>; }
+function SelectItem({ value, children }){ return <option value={value}>{children}</option>; }
+function Tabs({ value, onValueChange, children, ...props }){
+  return <div {...props}>{React.Children.map(children, child => {
+    if(child.type === TabsList) return React.cloneElement(child, { value, onValueChange });
+    if(child.type === TabsContent && child.props.value === value) return child;
+    return null;
+  })}</div>;
+}
+function TabsList({ children, value, onValueChange, ...props }){
+  return <div {...props}>{React.Children.map(children, child => React.cloneElement(child, { onSelect:onValueChange, selected: child.props.value===value }))}</div>;
+}
+function TabsTrigger({ value, onSelect, children, ...props }){ return <button onClick={()=> onSelect(value)} {...props}>{children}</button>; }
+function TabsContent({ children, ...props }){ return <div {...props}>{children}</div>; }
+function Dialog({ open, children }){ return open? <div className="fixed inset-0 z-50"><div className="absolute inset-0"/> {children}</div> : null; }
+function DialogContent({ children, ...props }){ return <div {...props}>{children}</div>; }
+function DialogHeader({ children, ...props }){ return <div {...props}>{children}</div>; }
+function DialogTitle({ children, ...props }){ return <h3 {...props}>{children}</h3>; }
+function DialogFooter({ children, ...props }){ return <div {...props}>{children}</div>; }
+function Switch({ checked, onCheckedChange, ...props }){ return <input type="checkbox" checked={checked} onChange={e=> onCheckedChange(e.target.checked)} {...props}/>; }
+function Badge({ children, ...props }){ return <span {...props}>{children}</span>; }
 
 // ICONS (compact): single <Icon name="..."/> instead of many components
 // Reduces canvas length; no external fetches.
@@ -81,6 +107,7 @@ const CONFIG = {
   BUILDERBOT_BASE_URL: (window as any).ENV?.BUILDERBOT_BASE_URL || "http://localhost:3008",
   BUILDERBOT_API_KEY: (window as any).ENV?.BUILDERBOT_API_KEY || "",
   ASSISTANT_GATEWAY: (window as any).ENV?.ASSISTANT_GATEWAY || "http://localhost:3008",
+  WS_URL: (window as any).ENV?.WS_URL || "ws://localhost:4000",
 };
 
 const uid = () => Math.random().toString(36).slice(2);
@@ -99,7 +126,7 @@ const saveDB = (db: DB) => localStorage.setItem("agua_bambu_crm_db", JSON.string
 let waSocket: WebSocket | null = null;
 function initWASocket(){
   if(!waSocket || waSocket.readyState === WebSocket.CLOSED){
-    waSocket = new WebSocket('ws://localhost:4000');
+    waSocket = new WebSocket(CONFIG.WS_URL);
     waSocket.addEventListener('open', () => console.log('WhatsApp socket conectado'));
   }
 }
@@ -143,7 +170,7 @@ export default function CRMKommoStyle(){
 
   useEffect(()=>{
     if('serviceWorker' in navigator){
-      navigator.serviceWorker.register('/service-worker.js').catch(console.error);
+      navigator.serviceWorker.register('./service-worker.js').catch(console.error);
     }
     initWASocket();
     return () => { waSocket?.close(); };
@@ -499,3 +526,6 @@ function ChatsInbox({ leads, onOpen }:{ leads:Lead[]; onOpen:(id:string)=>void }
 
 // --- Self-tests compactos ---
 (function __tests__(){ try{ console.assert(/^\d{4}-\d{2}-\d{2}$/.test(todayISO()), 'todayISO'); const s=new Set(Array.from({length:5}, uid)); console.assert(s.size===5, 'uid unique'); console.assert(DEFAULT_STAGES.length>=4,'stages'); }catch(e){ console.warn('SelfTests:', e); } })();
+
+import { createRoot } from "https://esm.sh/react-dom@18/client";
+createRoot(document.getElementById('root')).render(<CRMKommoStyle />);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open('crm-bambu-cache').then(cache => cache.add('/manifest.json'))
+    caches.open('crm-bambu-cache').then(cache => cache.add('manifest.json'))
   );
 });
 


### PR DESCRIPTION
## Summary
- add `index.html` that loads JSX via Babel and relative manifest
- inline UI components and render via CDN modules
- document GitHub Pages entry setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb028d5a1c832da962d69707265810